### PR TITLE
Add projects description translation

### DIFF
--- a/src/locales/translations.js
+++ b/src/locales/translations.js
@@ -21,6 +21,7 @@ export const translations = {
     },
     projects: {
       heading: "Projetos",
+      description: "Você possui {count} projetos.",
       viewGithub: "Ver no GitHub"
     },
     blog: {
@@ -60,6 +61,7 @@ export const translations = {
     },
     projects: {
       heading: "Projects",
+      description: "You have {count} projects.",
       viewGithub: "View on GitHub"
     },
     blog: {

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -29,7 +29,7 @@ export function Projects() {
         {t("projects.heading")}
       </h1>
       <p className="text-gray-700 dark:text-gray-300 mb-6">
-        {t("projects.description", projetos.length)} {/* optional */}
+        {t("projects.description").replace("{count}", projetos.length)} {/* optional */}
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         {projetos.map((proj) => (


### PR DESCRIPTION
## Summary
- translate new `projects.description` in pt and en
- show project count in Projects page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684460f52e348333a70725e43310e897