### PR TITLE
Add translated footer copyright

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,11 @@
+import { useLanguage } from "../context/LanguageContext";
+
 export function Footer() {
+  const { t } = useLanguage();
+  const year = new Date().getFullYear();
   return (
     <footer className="py-6 text-center text-sm text-gray-500 dark:text-gray-400 border-t dark:border-gray-700">
-      © {new Date().getFullYear()} Henrique Almeida. Todos os direitos reservados.
+      {t("footer.copyright").replace("{year}", year)}
     </footer>
   );
 }

--- a/src/locales/translations.js
+++ b/src/locales/translations.js
@@ -36,6 +36,9 @@ export const translations = {
       linkedin: "LinkedIn",
       orEmail: " ou enviar um e-mail para ",
       email: "seuemail@exemplo.com"
+    },
+    footer: {
+      copyright: "© {year} Henrique Almeida. Todos os direitos reservados."
     }
   },
   en: {
@@ -75,6 +78,9 @@ export const translations = {
       linkedin: "LinkedIn",
       orEmail: " or send an email to ",
       email: "your.email@example.com"
+    },
+    footer: {
+      copyright: "© {year} Henrique Almeida. All rights reserved."
     }
   }
 };


### PR DESCRIPTION
## Summary
- add translated footer text in both locales
- pull footer text from useLanguage in Footer component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684460f46c90833384dda6d8a5fa5e10