### PR TITLE
Fix blog lint error

### DIFF
--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import { posts } from "../data/posts";
 import { loadPosts } from "../data/loadPosts";
 
 const posts = loadPosts();


### PR DESCRIPTION
## Summary
- remove duplicate `posts` import in Blog page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68446a7943088333b2cb2f7541865ac3