### PR TITLE
Fix missing provider and add comments

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,13 +8,12 @@ import { Contact } from "./pages/Contact";
 import { NotFound } from "./pages/NotFound";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
-
-
+// Provides theme state (light/dark) to the rest of the app
+import { ThemeProvider } from "./context/ThemeContext";
 
 export default function App() {
   return (
-
-    <LanguageProvider>
+    <ThemeProvider>
       <Router>
         <div className="min-h-screen bg-white text-black dark:bg-gray-900 dark:text-white">
           <Navbar />
@@ -32,7 +31,7 @@ export default function App() {
           <Footer />
         </div>
       </Router>
-    </LanguageProvider>
+    </ThemeProvider>
 
   );
 }

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 
+// Context used to share theme information across components
+
 const ThemeContext = createContext();
 
 export function ThemeProvider({ children }) {
@@ -22,6 +24,7 @@ export function ThemeProvider({ children }) {
     localStorage.setItem("theme", theme);
   }, [theme]);
 
+  // Simple toggle between light and dark modes
   const toggleTheme = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
   };


### PR DESCRIPTION
## Summary
- use `ThemeProvider` instead of removed `LanguageProvider`
- document theme context usage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68446b44decc8333b25866dabdd9ffaa