### PR TITLE
Fix blank page by using relative asset paths

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import md from 'vite-plugin-md';
 
 export default defineConfig({
+  // Use relative paths so the site works when opened from the file system
+  base: './',
   plugins: [
     react(),
     md({


### PR DESCRIPTION
## Summary
- use relative paths for built assets so pages work when opened directly

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68446f0dfcd08333a11e8b1b84e7b465