### PR TITLE
Refactor theme hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import { NotFound } from "./pages/NotFound";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
 // Provides theme state (light/dark) to the rest of the app
-import { ThemeProvider } from "./context/ThemeContext";
+import ThemeProvider from "./context/ThemeContext";
 
 export default function App() {
   return (

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,11 +1,11 @@
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useEffect, useState } from "react";
 
 // Context used to share theme information across components.
 // The current theme is persisted in localStorage so it survives page reloads.
 
-const ThemeContext = createContext();
+export const ThemeContext = createContext();
 
-export function ThemeProvider({ children }) {
+function ThemeProvider({ children }) {
   const getInitialTheme = () => {
     if (typeof window === "undefined") return "light";
     const stored = localStorage.getItem("theme");
@@ -37,6 +37,4 @@ export function ThemeProvider({ children }) {
   );
 }
 
-export function useTheme() {
-  return useContext(ThemeContext);
-}
+export default ThemeProvider;

--- a/src/context/useTheme.js
+++ b/src/context/useTheme.js
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { ThemeContext } from "./ThemeContext";
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export default useTheme;


### PR DESCRIPTION
## Summary
- move `useTheme` to its own file
- default export `ThemeProvider` from `ThemeContext.jsx`
- update imports

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684474fe7b188333a3a589a57404311d