### PR TITLE
Fix theme hook import and add comments

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router-dom";
-import { useTheme } from "../context/ThemeContext";
+// Custom hook that exposes the current theme and a toggle helper
+// The hook is defined in src/context/useTheme.js
+import useTheme from "../context/useTheme";
 
 
 export function Navbar() {
@@ -17,6 +19,7 @@ export function Navbar() {
           <Link to="/projects" className="hover:underline">Projects</Link>
           <Link to="/blog" className="hover:underline">Blog</Link>
           <Link to="/contact" className="hover:underline">Contact</Link>
+          {/* Toggle between light and dark mode */}
           <button
             type="button"
             onClick={toggleTheme}

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -6,6 +6,7 @@ import React, { createContext, useEffect, useState } from "react";
 export const ThemeContext = createContext();
 
 function ThemeProvider({ children }) {
+  // Determine the initial theme when the provider mounts
   const getInitialTheme = () => {
     if (typeof window === "undefined") return "light";
     const stored = localStorage.getItem("theme");
@@ -15,6 +16,7 @@ function ThemeProvider({ children }) {
 
   const [theme, setTheme] = useState(getInitialTheme);
 
+  // Whenever the theme changes, update the root element and save it
   useEffect(() => {
     const root = document.documentElement;
     if (theme === "dark") {

--- a/src/context/useTheme.js
+++ b/src/context/useTheme.js
@@ -1,6 +1,8 @@
 import { useContext } from "react";
 import { ThemeContext } from "./ThemeContext";
 
+// Convenience hook so components can access ThemeContext
+
 export function useTheme() {
   return useContext(ThemeContext);
 }

--- a/src/data/loadPosts.js
+++ b/src/data/loadPosts.js
@@ -1,14 +1,19 @@
 // Vite helper that eagerly imports all Markdown files from the posts folder
+// Eagerly import all Markdown files so the posts can be statically generated
 const modules = import.meta.glob('../posts/*.md', { as: 'raw', eager: true });
 
 // Simple front matter parser for the markdown files
+// It expects front matter in the form:
+// ---\ntitle: "My Title"\ndate: "2024-01-01"\n---\n
 function parseFrontMatter(raw) {
+  // Regex captures metadata between --- markers and the remaining Markdown
   const match = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/m.exec(raw);
   let metadata = {};
   let content = raw;
   if (match) {
     const fm = match[1];
     content = match[2];
+    // Parse each "key: value" line inside the front matter
     fm.split('\n').forEach((line) => {
       const idx = line.indexOf(":");
       if (idx !== -1) {

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,3 +1,4 @@
+// Allow customization via Vite environment variables when building the site
 const LINKEDIN_URL = import.meta.env.VITE_LINKEDIN_URL ||
   "https://linkedin.com/in/rickshf";
 const EMAIL = import.meta.env.VITE_CONTACT_EMAIL || "rickshf@example.com";
@@ -17,6 +18,7 @@ export function Contact() {
           LinkedIn
         </a>
         {" "}
+        {/* Show configured contact email */}
         or send an email to
         <a
           href={`mailto:${EMAIL}`}


### PR DESCRIPTION
## Summary
- fix incorrect `useTheme` import in `Navbar`
- document theme context usage and markdown loader
- improve Contact page env var docs

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844762a18008333a429037c25c8a731