### PR TITLE
Separate context export to remove ESLint warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ site, portanto não é necessário editar outros arquivos.
 
 ### Idioma e tema
 
-O gerenciamento de tema é feito em `src/context/ThemeContext.jsx`, que controla
-apenas o modo claro ou escuro. Não há variável de idioma definida nesse
-arquivo. Para habilitar o modo escuro do Tailwind, adicione a classe `dark` ao
-elemento `<html>` em `index.html`.
+O gerenciamento de tema é feito pelos arquivos `src/context/ThemeContext.js` e
+`src/context/ThemeContext.jsx`, que controlam apenas o modo claro ou escuro.
+Não há variável de idioma definida nesses arquivos. Para habilitar o modo
+escuro do Tailwind, adicione a classe `dark` ao elemento `<html>` em
+`index.html`.
 
 O conteúdo deste site está disponível em português e inglês.
 
@@ -96,6 +97,7 @@ This project is licensed under the [MIT License](LICENSE).
 
 ### Language and theme
 
-Theme management lives in `src/context/ThemeContext.jsx` and only handles the
-light/dark mode. There is no language variable defined in that context. To
-enable dark mode, add the `dark` class to the `<html>` element in `index.html`.
+Theme management lives in `src/context/ThemeContext.js` and
+`src/context/ThemeContext.jsx` and only handles the light/dark mode. There is no
+language variable defined in that context. To enable dark mode, add the `dark`
+class to the `<html>` element in `index.html`.

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const ThemeContext = createContext();

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,9 +1,9 @@
-import React, { createContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { ThemeContext } from "./ThemeContext";
 
 // Context used to share theme information across components.
 // The current theme is persisted in localStorage so it survives page reloads.
 
-export const ThemeContext = createContext();
 
 function ThemeProvider({ children }) {
   // Determine the initial theme when the provider mounts


### PR DESCRIPTION
## Summary
- split `ThemeContext` into its own file
- update provider to import the context
- document updated file layout in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68447975be6c8333a0d520ab15203684