### PR TITLE
Enhance blog post listing

### DIFF
--- a/src/data/loadPosts.js
+++ b/src/data/loadPosts.js
@@ -1,6 +1,10 @@
 // Vite helper that eagerly imports all Markdown files from the posts folder
-// Eagerly import all Markdown files so the posts can be statically generated
-const modules = import.meta.glob('../posts/*.md', { as: 'raw', eager: true });
+// Use the modern "query" option to read the raw Markdown content
+const modules = import.meta.glob('../posts/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
 
 // Simple front matter parser for the markdown files
 // It expects front matter in the form:
@@ -29,6 +33,16 @@ function parseFrontMatter(raw) {
   return { metadata, content };
 }
 
+// Grab the first non-empty line of the Markdown as a short preview
+function getExcerpt(content) {
+  const line = content
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l);
+  if (!line) return '';
+  return line.replace(/^#+\s*/, '').slice(0, 140);
+}
+
 // Load all posts and return them sorted by date (newest first)
 export function loadPosts() {
   return Object.entries(modules)
@@ -40,6 +54,7 @@ export function loadPosts() {
         title: metadata.title || slug,
         date: metadata.date || '',
         content,
+        excerpt: getExcerpt(content),
       };
     })
     .sort((a, b) => new Date(b.date) - new Date(a.date));

--- a/src/data/loadPosts.test.js
+++ b/src/data/loadPosts.test.js
@@ -9,9 +9,11 @@ describe('loadPosts', () => {
 
     expect(primeiro.title).toBe('Por que escolhi Tailwind para meu portf\u00f3lio');
     expect(primeiro.date).toBe('2025-05-21');
+    expect(primeiro.excerpt).toBe('Tailwind CSS permite um design funcional e limpo com extrema flexibilidade.');
 
     expect(python.title).toBe('Como instalar Python');
     expect(python.date).toBe('2025-06-07');
+    expect(python.excerpt).toBe('Python \u00e9 uma linguagem de programa\u00e7\u00e3o popular e vers\u00e1til. Neste post mostro como instal\u00e1-la em diferentes sistemas operacionais.');
   });
 
   it('returns posts sorted from newest to oldest', () => {

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -14,7 +14,10 @@ export function Blog() {
       <div className="mt-8 space-y-10">
         {/* List each post with a link to its detail page */}
         {posts.map((post) => (
-          <article key={post.slug} className="border-b pb-6 dark:border-gray-700">
+          <article
+            key={post.slug}
+            className="border-b pb-6 dark:border-gray-700"
+          >
             <Link
               to={`/blog/${post.slug}`}
               className="text-2xl font-semibold text-blue-600 dark:text-blue-400 hover:underline"
@@ -24,6 +27,9 @@ export function Blog() {
             <time className="block text-sm text-gray-500 dark:text-gray-400 mb-2">
               {post.date}
             </time>
+            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
+              {post.excerpt}
+            </p>
           </article>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- parse Markdown with modern `import.meta.glob` API
- derive post excerpts from content
- show excerpt in the blog list view
- update tests for new excerpt field

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447ab0f0708333b1e0bc1ee1744153