### PR TITLE
Fix ThemeProvider import path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import { NotFound } from "./pages/NotFound";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
 // Provides theme state (light/dark) to the rest of the app
-import ThemeProvider from "./context/ThemeContext";
+import ThemeProvider from "./context/ThemeContext.jsx";
 
 export default function App() {
   return (


### PR DESCRIPTION
## Summary
- fix import path for ThemeProvider to include file extension

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447cea603883339298c4d8fc59f618