### PR TITLE
Fix CRLF front matter parsing

### DIFF
--- a/src/data/loadPosts.js
+++ b/src/data/loadPosts.js
@@ -10,8 +10,9 @@ const modules = import.meta.glob('../posts/*.md', {
 // It expects front matter in the form:
 // ---\ntitle: "My Title"\ndate: "2024-01-01"\n---\n
 function parseFrontMatter(raw) {
-  // Regex captures metadata between --- markers and the remaining Markdown
-  const match = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/m.exec(raw);
+  // Regex captures metadata between --- markers and the remaining Markdown.
+  // Support both LF and CRLF line endings.
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/m.exec(raw);
   let metadata = {};
   let content = raw;
   if (match) {

--- a/src/data/loadPosts.test.js
+++ b/src/data/loadPosts.test.js
@@ -22,4 +22,13 @@ describe('loadPosts', () => {
     const sorted = [...dates].sort((a,b) => new Date(b) - new Date(a));
     expect(dates).toEqual(sorted);
   });
+
+  it('handles posts with CRLF line endings', () => {
+    const posts = loadPosts();
+    const crlf = posts.find(p => p.slug === 'crlf-post');
+    expect(crlf).toBeDefined();
+    expect(crlf.title).toBe('Post CRLF');
+    expect(crlf.date).toBe('2025-07-01');
+    expect(crlf.excerpt).toBe('Este post tem CRLF.');
+  });
 });

--- a/src/posts/crlf-post.md
+++ b/src/posts/crlf-post.md
@@ -1,0 +1,6 @@
+---
+title: "Post CRLF"
+date: "2025-07-01"
+---
+
+Este post tem CRLF.


### PR DESCRIPTION
## Summary
- handle Windows-style CRLF newlines in `parseFrontMatter`
- test that CRLF Markdown files load correctly
- add sample CRLF post used in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447cec27788333abd3b3e319ef4a2f