### PR TITLE
Fix gitignore for static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ node_modules
 dist
 dist-ssr
 *.local
-public
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## Summary
- keep public assets in version control by removing `public` from `.gitignore`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844816939c08333ab1a0fece81c048c