### PR TITLE
Refactor ThemeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ site, portanto não é necessário editar outros arquivos.
 
 ### Idioma e tema
 
-O gerenciamento de tema é feito pelo arquivo `src/context/ThemeContext.jsx`,
-que controla apenas o modo claro ou escuro.
+O gerenciamento de tema é feito pelos arquivos `src/context/ThemeContext.js` e
+`src/context/ThemeProvider.jsx`, que controlam apenas o modo claro ou escuro.
 Não há variável de idioma definida nesses arquivos. Para habilitar o modo
 escuro do Tailwind, adicione a classe `dark` ao elemento `<html>` em
 `index.html`.
@@ -109,7 +109,7 @@ An example file called `.env.example` is provided; copy it to `.env` and adjust 
 
 ### Language and theme
 
-Theme management lives in `src/context/ThemeContext.jsx` and only handles the
+Theme management lives in `src/context/ThemeContext.js` and `src/context/ThemeProvider.jsx` and only handles the
 light/dark mode. There is no
 language variable defined in that context. To enable dark mode, add the `dark`
 class to the `<html>` element in `index.html`.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import { NotFound } from "./pages/NotFound";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
 // Provides theme state (light/dark) to the rest of the app
-import ThemeProvider from "./context/ThemeContext.jsx";
+import ThemeProvider from "./context/ThemeProvider.jsx";
 
 export default function App() {
   return (

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const ThemeContext = createContext();

--- a/src/context/ThemeProvider.jsx
+++ b/src/context/ThemeProvider.jsx
@@ -1,12 +1,11 @@
-import React, { createContext, useEffect, useState } from "react";
-
-export const ThemeContext = createContext();
+import { useEffect, useState } from "react";
+import { ThemeContext } from "./ThemeContext";
 
 // Context used to share theme information across components.
 // The current theme is persisted in localStorage so it survives page reloads.
 
 
-function ThemeProvider({ children }) {
+export function ThemeProvider({ children }) {
   // Determine the initial theme when the provider mounts
   const getInitialTheme = () => {
     if (typeof window === "undefined") return "light";


### PR DESCRIPTION
## Summary
- create a dedicated `ThemeContext.js`
- split `ThemeProvider` into its own module and update imports
- document new file names in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844816b44ec83339b800672b7aed25e