### PR TITLE
Secure markdown rendering in Post page

### DIFF
--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -32,7 +32,7 @@ export function Post() {
       <time className="block text-sm text-gray-500">{post.date}</time>
       <div className="prose dark:prose-invert max-w-none">
         {/* Render the Markdown content of the post */}
-        <ReactMarkdown>{post.content}</ReactMarkdown>
+        <ReactMarkdown skipHtml>{post.content}</ReactMarkdown>
       </div>
       <Link to="/blog" className="text-blue-500 hover:underline">
         ← Back to blog


### PR DESCRIPTION
## Summary
- prevent raw HTML from rendering in blog posts by using `skipHtml` in `ReactMarkdown`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68448504b6608333a67a48e5c90c248d