### PR TITLE
Fix router basename

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import ThemeProvider from "./context/ThemeProvider.jsx";
 export default function App() {
   return (
     <ThemeProvider>
-      <Router>
+      <Router basename={import.meta.env.BASE_URL}>
         <div className="min-h-screen bg-white text-black dark:bg-gray-900 dark:text-white">
           <Navbar />
           <main className="max-w-4xl mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- ensure `Router` uses the Vite base URL

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68448505cba08333919ee00d41e7f6b1