### PR TITLE
Localize site para português

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Não há variável de idioma definida nesses arquivos. Para habilitar o modo
 escuro do Tailwind, adicione a classe `dark` ao elemento `<html>` em
 `index.html`.
 
-O conteúdo deste site está disponível em português e inglês.
+Todo o conteúdo deste site está disponível apenas em português.
 
 ## English
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     <meta charset="UTF-8" />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ export function Footer() {
   const year = new Date().getFullYear();
   return (
     <footer className="py-6 text-center text-sm text-gray-500 dark:text-gray-400 border-t dark:border-gray-700">
-      © {year} Henrique Almeida. All rights reserved.
+      © {year} Henrique Almeida. Todos os direitos reservados.
     </footer>
   );
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -14,11 +14,11 @@ export function Navbar() {
           rickshf
         </Link>
         <div className="flex items-center space-x-4">
-          <Link to="/" className="hover:underline">Home</Link>
-          <Link to="/about" className="hover:underline">About</Link>
-          <Link to="/projects" className="hover:underline">Projects</Link>
+          <Link to="/" className="hover:underline">Início</Link>
+          <Link to="/about" className="hover:underline">Sobre</Link>
+          <Link to="/projects" className="hover:underline">Projetos</Link>
           <Link to="/blog" className="hover:underline">Blog</Link>
-          <Link to="/contact" className="hover:underline">Contact</Link>
+          <Link to="/contact" className="hover:underline">Contato</Link>
           {/* Toggle between light and dark mode */}
           <button
             type="button"

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -2,13 +2,13 @@ export function About() {
   return (
     <section className="max-w-3xl mx-auto px-4 py-16 space-y-6">
       <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
-        About me
+        Sobre mim
       </h1>
       <p className="text-gray-700 dark:text-gray-300 text-lg leading-relaxed">
-        My name is Henrique Almeida (rickshf). I'm a web developer focusing on performance, accessibility, and simplicity. I enjoy creating clean and functional interfaces with modern technologies like React, Tailwind CSS, and Vite.
+        Meu nome é Henrique Almeida (rickshf). Sou desenvolvedor web com foco em performance, acessibilidade e simplicidade. Gosto de criar interfaces limpas e funcionais com tecnologias modernas como React, Tailwind CSS e Vite.
       </p>
       <p className="text-gray-700 dark:text-gray-300 text-lg leading-relaxed">
-        Besides programming, I'm interested in minimalist design, open source software, and digital productivity.
+        Além de programar, tenho interesse em design minimalista, software livre e produtividade digital.
       </p>
     </section>
   );

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -6,9 +6,9 @@ const EMAIL = import.meta.env.VITE_CONTACT_EMAIL || "rickshf@example.com";
 export function Contact() {
   return (
     <section>
-      <h2 className="text-3xl font-bold mb-4">Contact</h2>
+      <h2 className="text-3xl font-bold mb-4">Contato</h2>
       <p className="text-gray-700 dark:text-gray-300">
-        You can find me on
+        Você me encontra no
         <a
           href={LINKEDIN_URL}
           className="underline text-blue-600 dark:text-blue-400"
@@ -19,7 +19,7 @@ export function Contact() {
         </a>
         {" "}
         {/* Show configured contact email */}
-        or send an email to
+        ou envie um e-mail para
         <a
           href={`mailto:${EMAIL}`}
           className="underline text-blue-600 dark:text-blue-400"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,7 +10,7 @@ export function Home() {
       </h1>
 
       <p className="text-lg sm:text-xl text-gray-700 dark:text-gray-300 max-w-xl leading-relaxed mb-10">
-        Web developer focusing on minimalism, clean code and best practices.
+        Desenvolvedor web focado em minimalismo, código limpo e boas práticas.
       </p>
 
       <div className="flex flex-wrap justify-center gap-4">
@@ -18,19 +18,19 @@ export function Home() {
           to="/projects"
           className="px-6 py-2 text-sm border rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition"
         >
-          My Projects
+          Projetos
         </Link>
         <Link
           to="/about"
           className="px-6 py-2 text-sm border rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition"
         >
-          About me
+          Sobre mim
         </Link>
         <Link
           to="/contact"
           className="px-6 py-2 text-sm border rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition"
         >
-          Contact
+          Contato
         </Link>
       </div>
     </section>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,9 +3,9 @@ import { Link } from "react-router-dom";
 export function NotFound() {
   return (
     <section className="max-w-3xl mx-auto px-4 py-16 text-center space-y-4">
-      <h1 className="text-2xl font-bold">Page not found</h1>
+      <h1 className="text-2xl font-bold">Página não encontrada</h1>
       <Link to="/" className="text-blue-500 hover:underline">
-        Go back home
+        Voltar para a home
       </Link>
     </section>
   );

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -16,9 +16,9 @@ export function Post() {
   if (!post) {
     return (
       <section className="max-w-3xl mx-auto px-4 py-16">
-        <h1 className="text-2xl font-bold">Post not found</h1>
+        <h1 className="text-2xl font-bold">Post não encontrado</h1>
         <Link to="/blog" className="text-blue-500 hover:underline">
-          ← Back to blog
+          ← Voltar para o blog
         </Link>
       </section>
     );
@@ -35,7 +35,7 @@ export function Post() {
         <ReactMarkdown skipHtml>{post.content}</ReactMarkdown>
       </div>
       <Link to="/blog" className="text-blue-500 hover:underline">
-        ← Back to blog
+        ← Voltar para o blog
       </Link>
     </section>
   );

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -25,10 +25,10 @@ export function Projects() {
   return (
     <section className="max-w-4xl mx-auto px-4 py-16">
       <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-8">
-        Projects
+        Projetos
       </h1>
       <p className="text-gray-700 dark:text-gray-300 mb-6">
-        You have {projects.length} projects.
+        Você tem {projects.length} projetos.
       </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           {/* Render a simple card for each project */}
@@ -38,7 +38,7 @@ export function Projects() {
               {proj.title}
             </h2>
             <p className="text-gray-700 dark:text-gray-300 mb-3">
-              {proj.desc.en}
+              {proj.desc.pt}
             </p>
             {proj.link !== "#" && (
               <a
@@ -47,7 +47,7 @@ export function Projects() {
                 rel="noopener noreferrer"
                 className="text-sm underline text-blue-500 dark:text-blue-400"
               >
-                View on GitHub
+                Ver no GitHub
               </a>
             )}
           </div>


### PR DESCRIPTION
## Summary
- translate navigation and pages to Portuguese
- update footer copy
- set site language to pt-BR
- note Portuguese-only content in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845f89536b083339eb0dc51990d8629