### PR TITLE
Handle invalid post dates

### DIFF
--- a/src/data/loadPosts.js
+++ b/src/data/loadPosts.js
@@ -50,13 +50,21 @@ export function loadPosts() {
     .map(([path, raw]) => {
       const { metadata, content } = parseFrontMatter(raw);
       const slug = path.split('/').pop().replace(/\.md$/, '');
+      const rawDate = metadata.date || '';
+      const parsed = new Date(rawDate);
+      const safeDate = isNaN(parsed) ? new Date(0) : parsed;
       return {
         slug,
         title: metadata.title || slug,
-        date: metadata.date || '',
+        date: rawDate,
         content,
         excerpt: getExcerpt(content),
+        _dateObj: safeDate,
       };
     })
-    .sort((a, b) => new Date(b.date) - new Date(a.date));
+    .sort((a, b) => b._dateObj - a._dateObj)
+    .map((post) => {
+      const { _dateObj, ...rest } = post;
+      return rest;
+    });
 }

--- a/src/data/loadPosts.test.js
+++ b/src/data/loadPosts.test.js
@@ -31,4 +31,12 @@ describe('loadPosts', () => {
     expect(crlf.date).toBe('2025-07-01');
     expect(crlf.excerpt).toBe('Este post tem CRLF.');
   });
+
+  it('places posts with invalid dates last', () => {
+    const posts = loadPosts();
+    const invalid = posts.find(p => p.slug === 'invalid-date-post');
+    expect(invalid).toBeDefined();
+    expect(invalid.date).toBe('not-a-date');
+    expect(posts[posts.length - 1].slug).toBe('invalid-date-post');
+  });
 });

--- a/src/posts/invalid-date-post.md
+++ b/src/posts/invalid-date-post.md
@@ -1,0 +1,6 @@
+---
+title: "Invalid Date Post"
+date: "not-a-date"
+---
+
+Post with invalid date.


### PR DESCRIPTION
## Summary
- ensure `loadPosts` falls back to epoch when date metadata isn't valid
- add an example post with an invalid date for testing
- test ordering with invalid date posts

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f8966fb08333815131b65ddc110f