### PR TITLE
Remove Portuguese descriptions from projects

### DIFF
--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -5,7 +5,6 @@ const projects = [
     slug: "portfolio",
     title: "Portfolio",
     desc: {
-      pt: "Este próprio portfólio, construído com React, Tailwind e Vite.",
       en: "This very portfolio, built with React, Tailwind and Vite."
     },
     link: "https://github.com/rickshf"
@@ -14,7 +13,6 @@ const projects = [
     slug: "soon",
     title: "Em breve",
     desc: {
-      pt: "Aplicativos, ferramentas e contribuições open source.",
       en: "Apps, tools and open source contributions."
     },
     link: "#"


### PR DESCRIPTION
## Summary
- prune unused Portuguese project descriptions as the app doesn't support multiple languages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845f89a889483338a15d8913004c50f