### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint and test using Node 18

## Testing
- `npm ci`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845fee73ea08333b0cf152d69331d3d