### PR TITLE
Add projects data file and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Para adicionar um novo post, basta colocar um arquivo Markdown em `src/posts/`
 com `title` e `date` no cabeçalho. Os arquivos são lidos automaticamente pelo
 site, portanto não é necessário editar outros arquivos.
 
+### Formato do `projects.json`
+
+Os projetos exibidos na página são definidos no arquivo `src/data/projects.json`.
+Ele contém um array de objetos com os campos `slug`, `title`, `desc.pt`,
+`desc.en` e `link`. Edite esse arquivo para adicionar ou remover projetos.
+
 ### Idioma e tema
 
 O gerenciamento de tema é feito pelos arquivos `src/context/ThemeContext.js` e
@@ -122,6 +128,12 @@ An example file called `.env.example` is provided; copy it to `.env` and adjust 
 
 1. Add a Markdown file in `src/posts/` with a `title` and `date` front matter.
    The site will pick it up automatically; no other files need to be changed.
+
+### Projects file format
+
+The Projects page reads from `src/data/projects.json`. Each entry has `slug`,
+`title`, `desc.pt`, `desc.en` and `link` fields. Edit this file to add or remove
+projects.
 
 ### Language and theme
 

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,0 +1,20 @@
+[
+  {
+    "slug": "portfolio",
+    "title": "Portfolio",
+    "desc": {
+      "pt": "Este próprio portfólio, construído com React, Tailwind e Vite.",
+      "en": "This very portfolio, built with React, Tailwind and Vite."
+    },
+    "link": "https://github.com/rickshf"
+  },
+  {
+    "slug": "soon",
+    "title": "Em breve",
+    "desc": {
+      "pt": "Aplicações, ferramentas e contribuições open source.",
+      "en": "Apps, tools and open source contributions."
+    },
+    "link": "#"
+  }
+]

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,25 +1,6 @@
 
-// Static list of projects shown on the Projects page
-const projects = [
-  {
-    slug: "portfolio",
-    title: "Portfolio",
-    desc: {
-      pt: "Este próprio portfólio, construído com React, Tailwind e Vite.",
-      en: "This very portfolio, built with React, Tailwind and Vite."
-    },
-    link: "https://github.com/rickshf"
-  },
-  {
-    slug: "soon",
-    title: "Em breve",
-    desc: {
-      pt: "Aplicações, ferramentas e contribuições open source.",
-      en: "Apps, tools and open source contributions."
-    },
-    link: "#"
-  }
-];
+// Project data is defined in ../data/projects.json
+import projects from "../data/projects.json";
 
 export function Projects() {
   return (


### PR DESCRIPTION
## Summary
- create `src/data/projects.json` with project details
- load project list from JSON in `Projects.jsx`
- document the projects file format in both Portuguese and English sections of the README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845feead8748333b427b099e51eebf4