### PR TITLE
Update README with lint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Altere os valores conforme desejar.
    ```bash
    npm run lint
    ```
+   **Obs.:** rode `npm install` antes de executar `npm run lint`.
 
 5. Execute os testes (rode `npm install` antes, se necessário):
 
@@ -53,6 +54,14 @@ Altere os valores conforme desejar.
    ```bash
    npm run preview
    ```
+
+### Docker (opcional)
+
+Use o container oficial do Node para rodar lint e testes:
+
+```bash
+docker run --rm -it -v $(pwd):/app -w /app node:18 bash -c "npm install && npm run lint && npm test"
+```
 
 ### Personalizando links de contato
 
@@ -117,6 +126,7 @@ Then adjust the values as needed.
    ```bash
    npm run lint
    ```
+   **Note:** run `npm install` before `npm run lint`.
 
 5. Run the tests (run `npm install` first if needed):
 
@@ -129,6 +139,14 @@ Then adjust the values as needed.
    ```bash
    npm run preview
    ```
+
+### Docker (optional)
+
+Run lint and tests inside the official Node container:
+
+```bash
+docker run --rm -it -v $(pwd):/app -w /app node:18 bash -c "npm install && npm run lint && npm test"
+```
 
 ### Customizing contact links
 


### PR DESCRIPTION
## Summary
- clarify that `npm install` must run before `npm run lint`
- add optional Docker examples for running lint and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684600891fc8833398651942e08894c3